### PR TITLE
bump go version to fix security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 AS builder
+FROM golang:1.22.5 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
The existing Version of Go 1.21 used to create the latest ollama-operator:0.7.1 has a Critical CVE.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-24790

(When scanned by Prisma)

Type | Highest severity | Description
-- | -- | --
go | critical | net/netip version 1.21.9 has 1 vulnerability


Severity | Package | CVE | Fix Status | Grace period | Risk factors | Description | Tags
-- | -- | -- | -- | -- | -- | -- | --
critical | net/netip | CVE-2024-24790 | Fixed in:1.21.11, 1.22.448 days ago |   | 6 | Impacted versions: <v1.21.11Discovered: 22 days agoPublished: 48 days agoPath: /kollama
he various Is methods (IsPrivate, IsLoopback, etc) did not work as expected for IPv4-mapped IPv6 addresses, returning false for addresses which would return true in their traditional IPv4 forms.

This can be fixed updating Go to 1.22.5

Here is a scan after that Docker is rebuilt with the PR File.


Vulnerabilities found for image ollama-operator-go1-22-5:latest: total - 1, critical - 0, high - 0, medium - 1, low - 0
Vulnerability threshold check results: PASS

go | medium | golang.org/x/net/http2 version v0.19.0 has 1 vulnerability
-- | -- | --

This fixes the CRITICAL CVE.

It would be great to get this fixe in ASAP and get a new Docker image.
