### PR TITLE
bump kube-rbac-proxy and switch source in k8s install file

### DIFF
--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -590,7 +590,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
The current K8s deployment file uses `gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0` that contains a number of Security CVE's.

kube-rbac-proxy:v0.15.0
Image
kube-rbac-proxy:v0.15.0
+2 more
IDsha256:7ebda747308b686ef6471bd8377085bce9f210baef15ce2a9bb6c5d8ccd773dc
OS distributionDistroless (based on Debian GNU/Linux 11)
OS releasebullseye

 go	 critical	net/netip version 1.21.3 has 1 vulnerability
 go	 high	google.golang.org/grpc/internal/transport version v1.47.0 has 1 vulnerability
 go	 high	google.golang.org/grpc version v1.47.0 has 2 vulnerabilities
 go	 high	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc version v0.20.0 has 1 vulnerability

The choice of kube-rbac-proxy can be updated to a newer version (and source since `gcr.io/kubebuilder/kube-rbac-proxy` only supports `0.16.0`)

Scan results for: image quay.io/brancz/kube-rbac-proxy:v0.18.0 sha256:f11dcab913758ac5cdfdfb4c8209b0d1fd7bf3d22896e8b0e19518bea357de36

Vulnerabilities found for image quay.io/brancz/kube-rbac-proxy:v0.18.0: total - 3, critical - 0, high - 0, medium - 2, low - 1
Vulnerability threshold check results: PASS

![Screenshot 2024-07-24 at 2 41 34 PM](https://github.com/user-attachments/assets/5c1adb4e-4511-42b0-a9aa-a3f308bc4249)
![Screenshot 2024-07-24 at 2 42 06 PM](https://github.com/user-attachments/assets/b993e24c-c36f-493e-a4b7-c7c026c84993)

This will clean up the Security Issues.






